### PR TITLE
Ensure .git gets removed from git name for dir

### DIFF
--- a/addons.sh
+++ b/addons.sh
@@ -28,7 +28,9 @@ sleepinterval=${INTERVAL:-300}
 execcommand=${CMD}
 
 
+# get the name of the repo, but be sure to remove .git off the end if it exists
 reponame=$(basename $REPO)
+reponame=${reponame%%.*git}
 
 targetdir=$gdir/$reponame
 tmpoutdir=$outdir/$reponame


### PR DESCRIPTION
If the repo is specified as `https://github.com/foo/bar.git`, we want to use just `bar` as the directory name, not `bar.git`.