### PR TITLE
Add envsubst option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ Thus, your command should read kubernetes files from wherever it feels relevant 
 
 Wherein `./transform.sh` should read its files from the value of `$INDIR` and place them in `$OUTDIR`.
 
+In addition, we run `envsubst` on the cmdline, so any usage of `$INDIR` or `$OUTDIR` would be translated correctly. Thus, you could do the following in the command-line:
+
+```json
+{
+  "cmd": "./transform.sh -indir $INDIR -outdir $OUTDIR",
+}
+```
+
+
 ## Sample Configuration
 
 The following are example repository configs. They also are included in this repository as `kubesync.json` and `kubesync.yml`, respectively.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,7 +115,8 @@ preprocess() {
 
   if [ -n "$execcommand" ]; then
     log "INFO: Running transformation $execcommand"
-    INDIR=$targetdir OUTDIR=$tmpoutdir $execcommand
+    actualcommand=$(echo "$execcommand" | INDIR=$targetdir OUTDIR=$tmpoutdir envsubst)
+    INDIR=$targetdir OUTDIR=$tmpoutdir $actualcommand
     log "INFO: kubernetes yml dir set to outdir $tmpoutdir"
   elif [ -n "$ymldir" ]; then
     log "INFO: cmd empty, no transformation to run"


### PR DESCRIPTION
Enables ability to use `INDIR` and `OUTDIR` in command-line, e.g.

```json
{
  "cmd": "./transform.sh -i $INDIR -o $OUTDIR",
}
```