### PR TITLE
Fix README; add kubesync-deploy.yml

### DIFF
--- a/kubesync-deploy.yml
+++ b/kubesync-deploy.yml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubesync
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubesync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubesync
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubesync
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: kubesync
+  template:
+    metadata:
+      labels:
+        name: kubesync
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      serviceAccountName: kubesync
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoSchedule
+          operator: Exists
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      # we specifically want to run on master
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/role
+                  operator: In
+                  values: ["master"]
+      containers:
+      - name: kubesync
+        image: deitch/kubesync:3979032795afbee10324b5c75b84e25e7984fb55
+        envFrom:
+        - secretRef:
+            name: kubesync
+


### PR DESCRIPTION
As described. This allows people to deploy just by doing:

```
kubectl apply -f https://raw.githubusercontent.com/deitch/kubesync/master/kubesync-deploy.yml
```

Note that the secret `kubesync` with parameters must already exist in the `kube-system` namespace.